### PR TITLE
Issues #3 #4 #6 and #9 - minor touchups

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ in the details for our new project:
 At the time of writing, the latest version is `2.7.0`. You can check for the latest version on
 [Maven Central](https://repo1.maven.org/maven2/ca/corbett/swing-extras-archetype/).
 
+This archetype will generate a project with swing-extras version 2.7.0 as a dependency.
+The archetype patch version may increment independently of the swing-extras library version,
+but the `major.minor` will match the `major.minor` version of swing-extras it is designed to work with.
+For example, versions 2.6.0, 2.6.1, 2.6.2 of this archetype all generate projects with swing-extras 2.6.0,
+and version 2.7.0 of this archetype would generate projects with swing-extras 2.7.0.
+The swing-extras library does not normally have patch releases, so only `major.minor` actually matters.
+
 ### Required properties
 
 Regardless of which method you use to create your new project, you will need to provide values for the
@@ -50,6 +57,9 @@ following properties:
 - `artifactNamePascalCase`: the name of your application in PascalCase, e.g. `MyApp`
     - (this will be used in some class names, for example `MyAppExtensionManager` and `MyAppExtension`, so it cannot
       contain hyphens or spaces)
+
+The `artifactNameLowerCase` property is filled in for you automatically, and generally you do not need to provide it
+yourself.
 
 ### After generating your new project
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <!-- For example, versions 2.6.0, 2.6.1, 2.6.2 of this archetype all generate projects with swing-extras 2.6.0 -->
     <!-- And version 2.7.0 of this archetype would generate projects with swing-extras 2.7.0                       -->
     <!-- The swing-extras library does not normally have patch releases, so only major.minor actually matters.     -->
-    <version>2.7.0</version>
+    <version>2.7.0-SNAPSHOT</version> <!-- TODO remove SNAPSHOT before release -->
 
     <packaging>maven-archetype</packaging>
 

--- a/src/main/resources/archetype-resources/README.md
+++ b/src/main/resources/archetype-resources/README.md
@@ -20,5 +20,5 @@ TODO Insert license information here.
 
 #[[##]]# Version history
 
-Refer to the [Release Notes](${packageInPathFormat}/${artifactNameLowerCase}/ReleaseNotes.txt) for a detailed version
-history.
+Refer to the [Release Notes](src/main/resources/${packageInPathFormat}/${artifactNameLowerCase}/ReleaseNotes.txt) for
+a detailed version history.

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,6 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <!-- This project was generated from the swing-extras-archetype Maven archetype version 2.7.0 -->
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
@@ -19,6 +20,20 @@
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
             <version>2.7.0-SNAPSHOT</version> <!-- TODO remove SNAPSHOT before release -->
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.14.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR addresses issues #3, #4, #6, and #9 by making minor changes to the archetype:

- issue 3: add a comment to the generated `pom.xml` indicating which version of the archetype was used to generate the project
- issue 4: fix the broken link to ReleaseNotes.txt in the generated README.md
- issue 6: make sure the generated project has junit and mockito set up as test dependencies
- issue 9: explain the version number linkage between the archetype and the library in the archetype's README.md
