### PR TITLE
Issue #17 upgrade to swing-extras 2.8

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.7.0</version>
+            <version>2.8.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR addresses issue #17 by updating this archetype to include the latest swing-extras 2.8 release. The 2.8 release is still in SNAPSHOT, but this will be removed after the swing-extras release is finalized.

Despite several breaking changes between 2.7 and 2.8 of swing-extras, it's a pleasant surprise that none of those changes affect the code delivered by this archetype. So, this is just a straight version change.