### PR TITLE
2.9.0 release - including issue #23

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ replacing the placeholders with your own values:
 mvn archetype:generate \
   -DarchetypeGroupId=ca.corbett \
   -DarchetypeArtifactId=swing-extras-archetype \
-  -DarchetypeVersion=2.8.0 \
+  -DarchetypeVersion=2.9.0 \
   -DgroupId=com.example \
   -DartifactId=my-app \
   -Dversion=1.0.0 \
@@ -36,10 +36,10 @@ in the details for our new project:
 
 **Always use the latest version of the archetype!**
 
-At the time of writing, the latest version is `2.8.0`. You can check for the latest version on
+At the time of writing, the latest version is `2.9.0`. You can check for the latest version on
 [Maven Central](https://repo1.maven.org/maven2/ca/corbett/swing-extras-archetype/).
 
-This archetype will generate a project with swing-extras version 2.8.0 as a dependency.
+This archetype will generate a project with swing-extras version 2.9.0 as a dependency.
 The archetype patch version may increment independently of the swing-extras library version,
 but the `major.minor` will match the `major.minor` version of swing-extras it is designed to work with.
 For example, versions 2.6.0, 2.6.1, 2.6.2 of this archetype all generate projects with swing-extras 2.6.0,
@@ -148,6 +148,7 @@ Your skeletal application comes with many `swing-extras` features already wired 
       made. The MainWindow is wired up to receive UI reload events, and you can add your additional dialogs or UI
       classes to the notification list by implementing the `UIReloadable` interface, and adding your UI class as a
       listener to the `UIReloadAction` class.
+- **A fallback exception handler** - any uncaught exception in your application will be properly logged.
 - **Intelligent detection of your application environment.**
     - The `Version` class automatically detects your application's installation directory based on supplied environment
       variables, and also your application's configuration and extension directories. These are exposed to your

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <groupId>ca.corbett</groupId>
     <artifactId>swing-extras-archetype</artifactId>
 
-    <!-- This archetype will generate a project with swing-extras version 2.8.0 as a dependency.                   -->
+    <!-- This archetype will generate a project with swing-extras version 2.9.0 as a dependency.                   -->
     <!-- The archetype patch version may increment independently of the swing-extras library version,              -->
     <!-- but the major.minor will match the major.minor version of swing-extras it is designed to work with.       -->
     <!-- For example, versions 2.6.0, 2.6.1, 2.6.2 of this archetype all generate projects with swing-extras 2.6.0 -->
     <!-- And version 2.7.0 of this archetype would generate projects with swing-extras 2.7.0                       -->
     <!-- The swing-extras library does not normally have patch releases, so only major.minor actually matters.     -->
-    <version>2.8.0</version>
+    <version>2.9.0</version>
 
     <packaging>maven-archetype</packaging>
 

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- This project was generated from the swing-extras Maven archetype 2.8.0 -->
+    <!-- This project was generated from the swing-extras Maven archetype 2.9.0 -->
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.8.0</version>
+            <version>2.9.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/Main.java
+++ b/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/Main.java
@@ -1,5 +1,6 @@
 package ${package}.${artifactNameLowerCase};
 
+import ca.corbett.extras.FallbackExceptionHandler;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.SingleInstanceManager;
 import ca.corbett.updates.UpdateManager;
@@ -32,6 +33,9 @@ public class Main {
     public static void main(String[] args) {
         // Before we do anything else, set up logging:
         configureLogging();
+
+        // Set up a FallbackExceptionHandler for uncaught exceptions in any thread:
+        FallbackExceptionHandler.register();
 
         // Peek at our config file to see if single instance mode is enabled:
         boolean isSingleInstanceEnabled = Boolean.parseBoolean(AppConfig.peek(AppConfig.SINGLE_INSTANCE_PROP));


### PR DESCRIPTION
This PR prepares the archetype for a small `2.9.0` release with the following changes:

- update the project's `swing-extras` dependency from `2.8.0` to `2.9.0`
- issue #23 - make use of FallbackExceptionHandler

Closes #23 