### PR TITLE
Dev branch for 3.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ replacing the placeholders with your own values:
 mvn archetype:generate \
   -DarchetypeGroupId=ca.corbett \
   -DarchetypeArtifactId=swing-extras-archetype \
-  -DarchetypeVersion=2.9.0 \
+  -DarchetypeVersion=3.0.0 \
   -DgroupId=com.example \
   -DartifactId=my-app \
   -Dversion=1.0.0 \
@@ -36,10 +36,10 @@ in the details for our new project:
 
 **Always use the latest version of the archetype!**
 
-At the time of writing, the latest version is `2.9.0`. You can check for the latest version on
+At the time of writing, the latest version is `3.0.0`. You can check for the latest version on
 [Maven Central](https://repo1.maven.org/maven2/ca/corbett/swing-extras-archetype/).
 
-This archetype will generate a project with swing-extras version 2.9.0 as a dependency.
+This archetype will generate a project with swing-extras version `3.0.0` as a dependency.
 The archetype patch version may increment independently of the swing-extras library version,
 but the `major.minor` will match the `major.minor` version of swing-extras it is designed to work with.
 For example, versions 2.6.0, 2.6.1, 2.6.2 of this archetype all generate projects with swing-extras 2.6.0,

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <groupId>ca.corbett</groupId>
     <artifactId>swing-extras-archetype</artifactId>
 
-    <!-- This archetype will generate a project with swing-extras version 2.9.0 as a dependency.                   -->
+    <!-- This archetype will generate a project with swing-extras version 3.0.0 as a dependency.                   -->
     <!-- The archetype patch version may increment independently of the swing-extras library version,              -->
     <!-- but the major.minor will match the major.minor version of swing-extras it is designed to work with.       -->
     <!-- For example, versions 2.6.0, 2.6.1, 2.6.2 of this archetype all generate projects with swing-extras 2.6.0 -->
     <!-- And version 2.7.0 of this archetype would generate projects with swing-extras 2.7.0                       -->
     <!-- The swing-extras library does not normally have patch releases, so only major.minor actually matters.     -->
-    <version>2.9.0</version>
+    <version>3.0.0</version>
 
     <packaging>maven-archetype</packaging>
 
@@ -47,8 +47,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
                 <!-- For publishing to Maven Central: -->
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -4,14 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- This project was generated from the swing-extras Maven archetype 2.9.0 -->
+    <!-- This project was generated from the swing-extras Maven archetype 3.0.0 -->
     <groupId>${groupId}</groupId>
     <artifactId>${artifactId}</artifactId>
     <version>${version}</version>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>25</maven.compiler.source>
+        <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>2.9.0</version>
+            <version>3.0.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/Main.java
+++ b/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/Main.java
@@ -67,7 +67,7 @@ public class Main {
                    new Object[]{extManager.getLoadedExtensionCount(), extManager.getEnabledLoadedExtensions().size()});
 
         // Load our application configuration:
-        AppConfig.getInstance().load();
+        AppConfig.getInstance().reinitialize();
 
         // Parse update sources if provided, to enable dynamic extension discovery:
         parseUpdateSources();

--- a/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/ui/actions/LogConsoleAction.java
+++ b/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/ui/actions/LogConsoleAction.java
@@ -1,8 +1,9 @@
 package ${package}.${artifactNameLowerCase}.ui.actions;
 
 import ca.corbett.extras.logging.LogConsole;
+import ca.corbett.extras.EnhancedAction;
+import ${package}.${artifactNameLowerCase}.ui.MainWindow;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 
 /**
@@ -10,7 +11,9 @@ import java.awt.event.ActionEvent;
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
-public class LogConsoleAction extends AbstractAction {
+public class LogConsoleAction extends EnhancedAction {
+
+    private static boolean positionAdjusted = false;
 
     public LogConsoleAction() {
         super("Show Log Console");
@@ -18,6 +21,15 @@ public class LogConsoleAction extends AbstractAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        // The first time LogConsole is shown, we'll position it over the MainWindow.
+        // But LogConsole is a singleton hide-when-closed window, so if the user adjusts
+        // its position manually after bringing it up, and then closes it, we don't want
+        // to mess with it again.
+        if (!positionAdjusted) {
+            LogConsole.getInstance().setLocationRelativeTo(MainWindow.getInstance());
+            positionAdjusted = true;
+        }
+
         LogConsole.getInstance().setVisible(true);
     }
 }


### PR DESCRIPTION
All PRs for the `3.0.0` release should target this branch.

- Closes #25 - AppConfig initialization problem on startup
- Bump central-publishing-maven-plugin version to `0.9`
- Migrating from Java 17 to Java 25 (latest LTS)
- Now pulling swing-extras `3.0.0` (latest stable release)
- Adopt the LogConsole fix from the Snotes application for better initial positioning
