### PR TITLE
Issue #25 - fix AppConfig initialization problem on startup

### DIFF
--- a/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/Main.java
+++ b/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/Main.java
@@ -67,7 +67,7 @@ public class Main {
                    new Object[]{extManager.getLoadedExtensionCount(), extManager.getEnabledLoadedExtensions().size()});
 
         // Load our application configuration:
-        AppConfig.getInstance().load();
+        AppConfig.getInstance().reinitialize();
 
         // Parse update sources if provided, to enable dynamic extension discovery:
         parseUpdateSources();


### PR DESCRIPTION
This PR addresses issue #25 by fixing a potential AppConfig initialization problem when the generated application starts up. The problem is that a misbehaving application extension can prematurely create the singleton AppConfig class, leaving it in a partially-initialized state. The fix is to force an unconditional reload immediately after all extensions have been activated, to force AppConfig to perform a full reinitialization before proceeding with startup.

This fix has already been manually applied and verified in a couple of client applications, most notably ImageViewer, where the original issue was discovered.