### PR TITLE
Issue #25 followup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
                 <!-- For publishing to Maven Central: -->
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>swing-extras</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/ui/actions/LogConsoleAction.java
+++ b/src/main/resources/archetype-resources/src/main/java/__artifactNameLowerCase__/ui/actions/LogConsoleAction.java
@@ -1,8 +1,9 @@
 package ${package}.${artifactNameLowerCase}.ui.actions;
 
 import ca.corbett.extras.logging.LogConsole;
+import ca.corbett.extras.EnhancedAction;
+import ${package}.${artifactNameLowerCase}.ui.MainWindow;
 
-import javax.swing.*;
 import java.awt.event.ActionEvent;
 
 /**
@@ -10,7 +11,9 @@ import java.awt.event.ActionEvent;
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
-public class LogConsoleAction extends AbstractAction {
+public class LogConsoleAction extends EnhancedAction {
+
+    private static boolean positionAdjusted = false;
 
     public LogConsoleAction() {
         super("Show Log Console");
@@ -18,6 +21,15 @@ public class LogConsoleAction extends AbstractAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
+        // The first time LogConsole is shown, we'll position it over the MainWindow.
+        // But LogConsole is a singleton hide-when-closed window, so if the user adjusts
+        // its position manually after bringing it up, and then closes it, we don't want
+        // to mess with it again.
+        if (!positionAdjusted) {
+            LogConsole.getInstance().setLocationRelativeTo(MainWindow.getInstance());
+            positionAdjusted = true;
+        }
+
         LogConsole.getInstance().setVisible(true);
     }
 }


### PR DESCRIPTION
A quick followup to the previous PR for issue #25 to add a couple of other fixes:

- bump the `central-publishing-maven-plugin` version to `0.9`
- drop the `SNAPSHOT` from the swing-extras library version now that it's been released
- adopt the LogConsole fix from the Snotes application for better initial positioning
